### PR TITLE
[misc] windows setup improvement

### DIFF
--- a/mariadb_windows.py
+++ b/mariadb_windows.py
@@ -1,40 +1,53 @@
-import sys
 import os
-import string
+import platform
+import sys
 from winreg import *
 
+
 class MariaDBConfiguration():
-  lib_dirs= ""
-  libs= ""
-  version= ""
-  includes= ""
+    lib_dirs = ""
+    libs = ""
+    version = ""
+    includes = ""
+
 
 def get_config():
-  required_version="3.1.0"
+    required_version = "3.1.0"
 
-  try:
-    config_prg= os.environ["MARIADB_CC_DIR"]
-    cc_version= ["",""]
-    cc_instdir= [config_prg, ""]
-    print("using environment configuration " + config_prg)
-  except KeyError:
-    Registry= ConnectRegistry(None, HKEY_LOCAL_MACHINE)
-    Key= OpenKey(Registry, "SOFTWARE\MariaDB Corporation\MariaDB Connector C 64-bit")
-    if Key:
-      cc_version= QueryValueEx(Key, "Version")
-      if cc_version[0] < required_version:
-        print("MariaDB Connector/Python requires MariaDB Connector/C >= %s (found version: %s") % (required_version, cc_version[0])
+    try:
+        config_prg = os.environ["MARIADB_CC_INSTALL_DIR"]
+        cc_version = ["", ""]
+        cc_instdir = [config_prg, ""]
+        print("using environment configuration " + config_prg)
+    except KeyError:
 
-        sys.exit(2)
-      cc_instdir= QueryValueEx(Key, "InstallDir")
-    if cc_instdir is None:
-      print("Could not find InstallationDir of MariaDB Connector/C. Please make sure MariaDB Connector/C is installed or specify the InstallationDir of MariaDB Connector/C by setting the environment variable MARIADB_CC_INSTALL_DIR.")
-      sys.exit(3)
+        try:
+            local_reg = ConnectRegistry(None, HKEY_LOCAL_MACHINE)
+            if platform.architecture()[0] == '32bit':
+                connector_key = OpenKey(local_reg,
+                                        'SOFTWARE\\MariaDB Corporation\\MariaDB Connector C')
+            else:
+                connector_key = OpenKey(local_reg,
+                                        'SOFTWARE\\MariaDB Corporation\\MariaDB Connector C 64-bit',
+                                        access=KEY_READ | KEY_WOW64_64KEY)
 
-  
-  cfg= MariaDBConfiguration()
-  cfg.version= cc_version[0]
-  cfg.includes= [".\\include", cc_instdir[0] + "\\include", cc_instdir[0] + "\\include\\mysql"]
-  cfg.lib_dirs= [cc_instdir[0] + "\\lib"]
-  cfg.libs= ["mariadbclient", "ws2_32", "advapi32",  "kernel32",  "shlwapi", "crypt32"]
-  return cfg
+            cc_version = QueryValueEx(connector_key, "Version")
+            if cc_version[0] < required_version:
+                print(
+                         "MariaDB Connector/Python requires MariaDB Connector/C >= %s (found version: %s") \
+                     % (required_version, cc_version[0])
+                sys.exit(2)
+            cc_instdir = QueryValueEx(Key, "InstallDir")
+
+        except:
+            print("Could not find InstallationDir of MariaDB Connector/C. "
+                  "Please make sure MariaDB Connector/C is installed or specify the InstallationDir of "
+                  "MariaDB Connector/C by setting the environment variable MARIADB_CC_INSTALL_DIR.")
+            sys.exit(3)
+
+    cfg = MariaDBConfiguration()
+    cfg.version = cc_version[0]
+    cfg.includes = [".\\include", cc_instdir[0] + "\\include", cc_instdir[0] + "\\include\\mysql"]
+    cfg.lib_dirs = [cc_instdir[0] + "\\lib"]
+    cfg.libs = ["mariadbclient", "ws2_32", "advapi32", "kernel32", "shlwapi", "crypt32"]
+    return cfg


### PR DESCRIPTION
* Changing MARIADB_CC_DIR to MARIADB_CC_INSTALL_DIR according to error message
* handle non found key in registry
* searching C/C installation in registry version according to python type
* updating syntax to python recommendation

Not sure why the search in the windows registry, as the key "InstallDir" does not seem present when installing c/c