### PR TITLE
Importing (and thus exporting) class `connection`

### DIFF
--- a/mariadb/__init__.py
+++ b/mariadb/__init__.py
@@ -10,6 +10,7 @@ Minimum supported Python version is 3.6
 from ._mariadb import (
     BINARY,
     Binary,
+    connection,
     ConnectionPool,
     DATETIME,
     DataError,


### PR DESCRIPTION
The connection class is not exported. While you probably don't want to use it directly from your code, this also makes that you cannot use it for type hinting.