### PR TITLE
CONPY-243: quick fix

### DIFF
--- a/mariadb/__init__.py
+++ b/mariadb/__init__.py
@@ -146,6 +146,6 @@ def connect(*args, connectionclass=mariadb.connections.Connection, **kwargs):
     return connection
 
 
-client_version_info = tuple(int(x, 10) for x in mariadbapi_version.split('.'))
+client_version_info = tuple(int(x, 10) for x in mariadbapi_version.split('-')[0].split('.'))
 client_version = client_version_info[0] * 10000 +\
     client_version_info[1] * 1000 + client_version_info[2]


### PR DESCRIPTION
This small change allows for connections to mariadb < 10.6.

10.5 builds can have the build number as a dash after the version string (10.5.17-12)

This should not affect mariadb > 10.6 and allow for some back-compatibility.