### PR TITLE
remove unused variable

### DIFF
--- a/mariadb/mariadb_connection.c
+++ b/mariadb/mariadb_connection.c
@@ -818,8 +818,7 @@ static PyObject *MrdbConnection_warnings(MrdbConnection *self)
 static PyObject *MrdbConnection_escape_string(MrdbConnection *self,
         PyObject *str)
 {
-    PyObject *string= NULL,
-             *new_string= NULL;
+    PyObject *new_string= NULL;
     size_t from_length, to_length;
     char *from, *to;
 


### PR DESCRIPTION
When I was building mariadb package with pip I get this warning:
``` shell
mariadb/mariadb_connection.c: In function ‘MrdbConnection_escape_string’:
  mariadb/mariadb_connection.c:821:15: warning: unused variable ‘string’ [-Wunused-variable]
    821 |     PyObject *string= NULL,
        |               ^~~~~~
```