### PR TITLE
bug when I trying install the mariadb with pip

### DIFF
--- a/mariadb/mariadb_cursor.c
+++ b/mariadb/mariadb_cursor.c
@@ -1125,7 +1125,7 @@ MrdbCursor_execute_text(MrdbCursor *self, PyObject *stmt)
 {
     int rc;
     MYSQL *db;
-    const char *statement;
+    char *statement;
     size_t statement_len= 0;
 
     MARIADB_CHECK_CONNECTION(self->connection, NULL);
@@ -1135,7 +1135,7 @@ MrdbCursor_execute_text(MrdbCursor *self, PyObject *stmt)
         statement = PyUnicode_AsUTF8AndSize(stmt, (Py_ssize_t *)&statement_len);
     } else if (Py_TYPE(stmt) == &PyBytes_Type)
     {
-        PyBytes_AsStringAndSize(stmt, (char**)statement, (Py_ssize_t *)&statement_len);
+        PyBytes_AsStringAndSize(stmt, &statement, (Py_ssize_t *)&statement_len);
     }
     else {
         PyErr_SetString(PyExc_TypeError, "Parameter must be a string or bytes");

--- a/mariadb/mariadb_cursor.c
+++ b/mariadb/mariadb_cursor.c
@@ -1135,7 +1135,7 @@ MrdbCursor_execute_text(MrdbCursor *self, PyObject *stmt)
         statement = PyUnicode_AsUTF8AndSize(stmt, (Py_ssize_t *)&statement_len);
     } else if (Py_TYPE(stmt) == &PyBytes_Type)
     {
-        PyBytes_AsStringAndSize(stmt, &statement, (Py_ssize_t *)&statement_len);
+        PyBytes_AsStringAndSize(stmt, (char**)statement, (Py_ssize_t *)&statement_len);
     }
     else {
         PyErr_SetString(PyExc_TypeError, "Parameter must be a string or bytes");


### PR DESCRIPTION
I was not able to install mariadb-connector with pip because it was getting a compiler error when building.
Probably because one of the flags -Werror=format-security which treats warning as error.

The output of error:
``` shell
mariadb/mariadb_cursor.c: In function ‘MrdbCursor_execute_text’:
  mariadb/mariadb_cursor.c:1138:39: error: passing argument 2 of ‘PyBytes_AsStringAndSize’ from incompatible pointer type [-Wincompatible-pointer-types]
   1138 |         PyBytes_AsStringAndSize(stmt, &statement, (Py_ssize_t *)&statement_len);
        |                                       ^~~~~~~~~~
        |                                       |
        |                                       const char **
  In file included from /usr/include/python3.12/Python.h:50,
                   from ./include/mariadb_python.h:21,
                   from mariadb/mariadb_cursor.c:20:
  /usr/include/python3.12/bytesobject.h:56:12: note: expected ‘char **’ but argument is of type ‘const char **’
     56 |     char **s,           /* pointer to buffer variable */
        |     ~~~~~~~^
  error: command '/usr/bin/gcc' failed with exit code 1
```

Since the function PyBytes_AsStringAndSize from bytesobjects.h expectate a char** and not  a const char** I remove the "pass by reference" and add a explicit conversion of type of statement to (char**).

After that I could install the mariadb package with pip using the source code that I edit.