### PR TITLE
Actually call PyErr_Occured(), not just refer to its address

### DIFF
--- a/mariadb/mariadb_codecs.c
+++ b/mariadb/mariadb_codecs.c
@@ -1102,7 +1102,7 @@ mariadb_get_parameter_info(MrdbCursor *self,
         {
             uint64_t tmp= PyLong_AsLongLong(paramvalue.value);
 
-            if (tmp == (uint64_t)-1 && PyErr_Occurred)
+            if (tmp == (uint64_t)-1 && PyErr_Occurred())
             {
               param->is_unsigned= 1;
               PyErr_Clear();


### PR DESCRIPTION
Found via this GCC 14.2.0 warning:

```
mariadb/mariadb_codecs.c: In function ‘mariadb_get_parameter_info’:
mariadb/mariadb_codecs.c:1105:37: warning: the address of ‘PyErr_Occurred’ will always evaluate as ‘true’ [-Waddress]
 1105 |             if (tmp == (uint64_t)-1 && PyErr_Occurred)
```