### PR TITLE
Fix: SyntaxWarning: invalid escape sequence '\*'

### DIFF
--- a/mariadb/connectionpool.py
+++ b/mariadb/connectionpool.py
@@ -41,7 +41,7 @@ class ConnectionPool(object):
     - **`pool_size`** (``int``) - Size of pool. The Maximum allowed number is 64. Default to 5
     - **`pool_reset_connection`** (``bool``) - Will reset the connection before returning it to the pool. Default to True.
     - **`pool_validation_interval`** (``int``) - Specifies the validation interval in milliseconds after which the status of a connection requested from the pool is checked. A value of 0 means that the status will always be checked. Default to 500 (Added in version 1.1.6)
-    - **\*\*kwargs** - Optional additional connection arguments, as described in mariadb.connect() method.
+    - **\\*\\*kwargs** - Optional additional connection arguments, as described in mariadb.connect() method.
 
     """
 


### PR DESCRIPTION
Fixing the error I encountered in package version `1.1.14` when using `Python 3.13.9`.

```
/app/.venv/lib/python3.13/site-packages/mariadb/connectionpool.py:44: SyntaxWarning: invalid escape sequence '\*'
  - **\*\*kwargs** - Optional additional connection arguments, as described in mariadb.connect() method.
```

## Edit 20251128

I have no idea why the CI test mariadb 11.4 - python pypy3.11 is failing because of a change in a doc-string.