### PR TITLE
Performance optimizations:

### DIFF
--- a/mariadb/impl/client/async_client.py
+++ b/mariadb/impl/client/async_client.py
@@ -641,6 +641,7 @@ class AsyncClient(BaseClient):
             
             # Select appropriate row parser based on protocol
             row_parser = self._parse_binary_row_data if is_binary else self._parse_text_row_data
+            self._set_txt_converters(columns, config)
 
             # If unbuffered, create streaming result
             if not buffered:

--- a/mariadb/impl/client/base_client.py
+++ b/mariadb/impl/client/base_client.py
@@ -605,7 +605,7 @@ class BaseClient(ABC):
         row_values = [None] * num_cols
         pos = 0
         data_bytes = data.tobytes()  # Convert once for faster access
-        
+
         for i in range(num_cols):
             column = columns[i]
             # Read length-encoded integer for field length
@@ -614,7 +614,7 @@ class BaseClient(ABC):
                 length = length_byte
                 pos += 1
             elif (length_byte == 0xFB):
-                pos += 1                
+                pos += 1
                 continue
             elif length_byte == 0xFC:
                 length = _unpack_H(data, pos + 1)[0]
@@ -625,10 +625,29 @@ class BaseClient(ABC):
             else:
                 length = _unpack_Q(data, pos + 1)[0]
                 pos += 9
-            
+
             col_type = column.type
             if col_type in (FIELD_TYPE.TINY, FIELD_TYPE.SHORT, FIELD_TYPE.LONG, FIELD_TYPE.LONGLONG, FIELD_TYPE.INT24, FIELD_TYPE.YEAR):
                 row_values[i] = int(data_bytes[pos:pos + length])
+            elif col_type in (FIELD_TYPE.VARCHAR, FIELD_TYPE.BIT, FIELD_TYPE.ENUM, FIELD_TYPE.SET, \
+                              FIELD_TYPE.TINY_BLOB, FIELD_TYPE.MEDIUM_BLOB, FIELD_TYPE.LONG_BLOB, FIELD_TYPE.BLOB, FIELD_TYPE.VAR_STRING, \
+                              FIELD_TYPE.STRING, FIELD_TYPE.GEOMETRY):
+                # String types and others
+                if column.special_format:
+                    if column.ext_type_format == b'json':
+                        row_values[i] = data_bytes[pos:pos + length].decode('utf-8', errors='ignore')
+                    elif column.ext_type_name == b'inet6' or column.ext_type_name == b'inet4':
+                        row_values[i] = data_bytes[pos:pos + length].decode('ascii')
+                        if config.native_object:
+                            row_values[i] = ipaddress.ip_address(row_values[i])
+                    elif column.ext_type_name == b'uuid':
+                        row_values[i] = data_bytes[pos:pos + length].decode('ascii')
+                        if config.native_object:
+                            row_values[i] = uuid.UUID(row_values[i])
+                elif column.character_set == 63:  # Binary
+                    row_values[i] = data_bytes[pos:pos + length]
+                else:
+                    row_values[i] = data_bytes[pos:pos + length].decode('utf-8', errors='ignore')
             elif col_type in (FIELD_TYPE.FLOAT, FIELD_TYPE.DOUBLE):
                 row_values[i] = float(data_bytes[pos:pos + length].decode('ascii'))
             elif col_type in (FIELD_TYPE.DECIMAL, FIELD_TYPE.NEWDECIMAL):
@@ -681,26 +700,9 @@ class BaseClient(ABC):
                 row_values[i] = None
             elif col_type == FIELD_TYPE.JSON:
                 row_values[i] = data_bytes[pos:pos + length].decode('utf-8', errors='ignore')
-            else:
-                # String types and others
-                if column.special_format:
-                    if column.ext_type_format == b'json':
-                        row_values[i] = data_bytes[pos:pos + length].decode('utf-8', errors='ignore')
-                    elif column.ext_type_name == b'inet6' or column.ext_type_name == b'inet4':
-                        row_values[i] = data_bytes[pos:pos + length].decode('ascii')
-                        if config.native_object:
-                            row_values[i] = ipaddress.ip_address(row_values[i])
-                    elif column.ext_type_name == b'uuid':
-                        row_values[i] = data_bytes[pos:pos + length].decode('ascii')
-                        if config.native_object:
-                            row_values[i] = uuid.UUID(row_values[i])
-                elif column.character_set == 63:  # Binary
-                    row_values[i] = data_bytes[pos:pos + length]
-                else:
-                    row_values[i] = data_bytes[pos:pos + length].decode('utf-8', errors='ignore')
-            
+
             pos += length
-        
+
         return tuple(row_values)
 
     def _parse_binary_row_data(self, data: memoryview, columns: List[ColumnDefinitionPacket], config: 'Configuration', num_cols: int) -> tuple:
@@ -717,26 +719,12 @@ class BaseClient(ABC):
         for i in range(num_cols):
             column = columns[i]
 
-            if null_bitmap[(i + 2) // 8] & (1 << ((i + 2) % 8)):
-                row_values[i] = None
+            if null_bitmap[(i + 2) >> 3] & (1 << ((i + 2) & 7)):
                 continue
 
             # Decode based on field type
             field_type = column.type
-            
-            if field_type == FIELD_TYPE.TINY:
-                if (column.flags & FIELD_FLAG.UNSIGNED) != 0:
-                    row_values[i] = data[pos]
-                else:
-                    row_values[i] = _unpack_b(data, pos)[0]
-                pos += 1
-            elif field_type in (FIELD_TYPE.SHORT, FIELD_TYPE.YEAR):
-                if (column.flags & FIELD_FLAG.UNSIGNED) != 0:
-                    row_values[i] = _unpack_H(data, pos)[0]
-                else:
-                    row_values[i] = _unpack_h(data, pos)[0]
-                pos += 2
-            elif field_type in (FIELD_TYPE.LONG, FIELD_TYPE.INT24):
+            if field_type in (FIELD_TYPE.LONG, FIELD_TYPE.INT24):
                 if (column.flags & FIELD_FLAG.UNSIGNED) != 0:
                     row_values[i] = _unpack_I(data, pos)[0]
                 else:
@@ -748,6 +736,54 @@ class BaseClient(ABC):
                 else:
                     row_values[i] = _unpack_q(data, pos)[0]
                 pos += 8
+            elif field_type in (FIELD_TYPE.VARCHAR, FIELD_TYPE.BIT, FIELD_TYPE.ENUM, FIELD_TYPE.SET, \
+                                FIELD_TYPE.TINY_BLOB, FIELD_TYPE.MEDIUM_BLOB, FIELD_TYPE.LONG_BLOB, FIELD_TYPE.BLOB, FIELD_TYPE.VAR_STRING, \
+                                FIELD_TYPE.STRING, FIELD_TYPE.GEOMETRY):
+                # String types (VARCHAR, TEXT, BLOB, JSON, etc.) - length-encoded
+                length = data[pos]
+
+                if (length < 0xFB):
+                    pos += 1
+                elif length == 0xFC:
+                    length = _unpack_H(data, pos + 1)[0]
+                    pos += 3
+                elif length == 0xFD:
+                    length = struct.unpack('<I', data[pos+ 1:pos+4].tobytes() + b'\x00')[0]
+                    pos += 4
+                else:  # 0xFE
+                    length = _unpack_Q(data, pos + 1)[0]
+                    pos += 9
+
+                val = bytes(data[pos:pos + length])
+                if column.special_format:
+                    if column.ext_type_format == b'json':
+                        row_values[i] = val.decode('utf-8')
+                    elif column.ext_type_name == b'inet6' or column.ext_type_name == b'inet4':
+                        row_values[i] = val.decode('ascii')
+                        if config.native_object:
+                            row_values[i] = ipaddress.ip_address(row_values[i])
+                    elif column.ext_type_name == b'uuid':
+                        row_values[i] = val.decode('ascii')
+                        if config.native_object:
+                            row_values[i] = uuid.UUID(row_values[i])
+                elif column.character_set == 63 and field_type != FIELD_TYPE.JSON:  # Binary
+                    row_values[i] = val
+                else:
+                    row_values[i] = val.decode('utf-8', errors='ignore')
+                pos += length
+
+            elif field_type == FIELD_TYPE.TINY:
+                if (column.flags & FIELD_FLAG.UNSIGNED) != 0:
+                    row_values[i] = data[pos]
+                else:
+                    row_values[i] = _unpack_b(data, pos)[0]
+                pos += 1
+            elif field_type in (FIELD_TYPE.SHORT, FIELD_TYPE.YEAR):
+                if (column.flags & FIELD_FLAG.UNSIGNED) != 0:
+                    row_values[i] = _unpack_H(data, pos)[0]
+                else:
+                    row_values[i] = _unpack_h(data, pos)[0]
+                pos += 2
             elif field_type == FIELD_TYPE.FLOAT:
                 row_values[i] = _unpack_f(data, pos)[0]
                 pos += 4
@@ -822,40 +858,7 @@ class BaseClient(ABC):
                         row_values[i] = None
                 else:
                     row_values[i] = None
-            else:
-                # String types (VARCHAR, TEXT, BLOB, JSON, etc.) - length-encoded
-                length = data[pos]
 
-                if (length < 0xFB):
-                    pos += 1
-                elif length == 0xFC:
-                    length = _unpack_H(data, pos + 1)[0]
-                    pos += 3
-                elif length == 0xFD:
-                    length = struct.unpack('<I', data[pos+ 1:pos+4].tobytes() + b'\x00')[0]
-                    pos += 4
-                else:  # 0xFE
-                    length = _unpack_Q(data, pos + 1)[0]
-                    pos += 9
-
-                val = bytes(data[pos:pos + length])
-                if column.special_format:
-                    if column.ext_type_format == b'json':
-                        row_values[i] = val.decode('utf-8')
-                    elif column.ext_type_name == b'inet6' or column.ext_type_name == b'inet4':
-                        row_values[i] = val.decode('ascii')
-                        if config.native_object:
-                            row_values[i] = ipaddress.ip_address(row_values[i])
-                    elif column.ext_type_name == b'uuid':
-                        row_values[i] = val.decode('ascii')
-                        if config.native_object:
-                            row_values[i] = uuid.UUID(row_values[i])
-                elif column.character_set == 63 and field_type != FIELD_TYPE.JSON:  # Binary
-                    row_values[i] = val
-                else:
-                    row_values[i] = val.decode('utf-8', errors='ignore')
-                pos += length
-        
         return tuple(row_values)
 
         

--- a/mariadb/impl/client/base_client.py
+++ b/mariadb/impl/client/base_client.py
@@ -50,11 +50,134 @@ from mariadb_shared import constants
 from ..message.server.ok_packet import OkPacket
 from cachetools import LRUCache
 
+# text conversion functions 
+def parse_date_text(s: bytes):
+    # YYYY-MM-DD
+    _int = int
+    parts = _unpack_DATE_TEXT(s, 0)  # returns 5-tuple: year_b, sep1, month_b, sep2, day_b
+    # convert numeric positions to int, skip separators
+    year, month, day = (_int(parts[i]) for i in (0, 2, 4))
+
+    if year == 0 or month == 0 or day == 0:
+        return None
+    return datetime.date(int(year), int(month), int(day))
+
+def parse_time_text(s: bytes):
+    _int = int
+    negative = s[0] == 45  # ord('-')
+    if negative:
+        s = s[1:]
+    parts = s.split(b':')
+    if len(parts) != 3:
+        return None
+    hours = _int(parts[0])
+    minutes = _int(parts[1])
+    sec_parts = parts[2].split(b'.')
+    seconds = _int(sec_parts[0])
+    microseconds = _int(sec_parts[1].ljust(6, b'0')) if len(sec_parts) > 1 else 0
+    td = datetime.timedelta(hours=hours, minutes=minutes, seconds=seconds, microseconds=microseconds)
+    return -td if negative else td
+
+def parse_datetime_text(s: bytes):
+    """Convert YYYY-MM-DD HH:MM:SS[.ffffff] bytes to datetime.datetime, None for zero dates."""
+    if len(s) < 19:
+        return None
+
+    _int = int
+
+    parts = _unpack_DATETIME_TEXT(s, 0)  # 11 elements: y, _, m, _, d, _, h, _, mi, _, s
+    year, month, day, hour, minute, second = (_int(parts[i]) for i in (0, 2, 4, 6, 8, 10))
+
+    if year == 0 or month == 0 or day == 0:
+        return None
+
+    microseconds = 0
+    if len(s) > 19 and s[19] == ord('.'):
+        frac = s[20:]
+        l = len(frac)
+        if l >= 6:
+            microseconds = _int(frac[:6])
+        else:
+            microseconds = _int(frac) * (10 ** (6 - l))
+
+    return datetime.datetime(year, month, day, hour, minute, second, microseconds)
+
+def parse_uuid_bytes(s: bytes):
+    return uuid.UUID(s.decode('ascii'))
+
+def parse_ip_bytes(s: bytes):
+    return ipaddress.ip_address(s.decode('ascii'))
+
+def parse_json_bytes(s: bytes):
+    return s.decode('utf-8', errors='ignore')
+
+def parse_string_bytes(s: bytes):
+    return s.decode('utf-8', errors='ignore')
+
+def parse_decimal_bytes(s: bytes):
+    return decimal.Decimal(s.decode('ascii'))
+
+def parse_null(_):
+    return None
+
+def txt_conversion_table(columns, config):
+    table = []
+    for col in columns:
+        t = col.type
+        charset = getattr(col, 'character_set', None)
+        ext_type_name = getattr(col, 'ext_type_name', None)
+        ext_type_format = getattr(col, 'ext_type_format', None)
+
+        if t in (FIELD_TYPE.TINY, FIELD_TYPE.SHORT, FIELD_TYPE.LONG,
+                 FIELD_TYPE.LONGLONG, FIELD_TYPE.INT24, FIELD_TYPE.YEAR):
+            table.append(int)
+
+        elif t in (FIELD_TYPE.FLOAT, FIELD_TYPE.DOUBLE):
+            table.append(float)
+
+        elif t in (FIELD_TYPE.DECIMAL, FIELD_TYPE.NEWDECIMAL):
+            table.append(parse_decimal_bytes)
+
+        elif t in (FIELD_TYPE.VARCHAR, FIELD_TYPE.STRING, FIELD_TYPE.VAR_STRING, FIELD_TYPE.GEOMETRY,
+                   FIELD_TYPE.TINY_BLOB, FIELD_TYPE.MEDIUM_BLOB, FIELD_TYPE.LONG_BLOB, FIELD_TYPE.BLOB):
+
+            # special formats first
+            if ext_type_format == b'json':
+                table.append(parse_json_bytes)
+            elif ext_type_name in (b'inet4', b'inet6'):
+                table.append(parse_ip_bytes if getattr(config, 'native_object', False) else parse_string_bytes)
+            elif ext_type_name == b'uuid':
+                table.append(parse_uuid_bytes if getattr(config, 'native_object', False) else parse_string_bytes)
+            # binary check
+            elif charset == 63:
+                table.append(bytes)
+            # fallback text
+            else:
+                table.append(parse_string_bytes)
+
+        elif t in (FIELD_TYPE.DATE, FIELD_TYPE.NEWDATE):
+            table.append(parse_date_text)
+
+        elif t == FIELD_TYPE.TIME:
+            table.append(parse_time_text)
+
+        elif t in (FIELD_TYPE.DATETIME, FIELD_TYPE.TIMESTAMP):
+            table.append(parse_datetime_text)
+
+        elif t == FIELD_TYPE.NULL:
+            table.append(parse_null)
+
+        else:
+            table.append(parse_string_bytes)
+
+    return table
+
+
 class BaseClient(ABC):
     """
     Abstract base client for MariaDB connections
     
-    Contains all common logic shared between async and sync implementations.    
+    Contains all common logic shared between async and sync implementations.
     """
     
     # =========================================================================
@@ -97,6 +220,7 @@ class BaseClient(ABC):
         self.connect_timeout = configuration.connect_timeout
         self.cert_fingerprint_validator: Optional['SSLFingerprintValidator'] = None
         self.auth_plugin: Optional['AuthenticationPlugin'] = None
+        self.txt_conversion_table = None
         
         # Track active streaming (unbuffered) result at client level
         # This prevents "Commands out of sync" when multiple cursors share the same connection
@@ -596,6 +720,9 @@ class BaseClient(ABC):
 
         return converted_rows
 
+    def _set_txt_converters(self, columns, config):
+        self.txt_conversion_table= txt_conversion_table(columns, config)
+
     # =========================================================================
     # Row Data Parsing Methods
     # =========================================================================
@@ -606,9 +733,10 @@ class BaseClient(ABC):
         pos = 0
         data_bytes = data.tobytes()  # Convert once for faster access
 
-        for i in range(num_cols):
-            column = columns[i]
+        converters = self.txt_conversion_table
+
             # Read length-encoded integer for field length
+        for i in range(num_cols):
             length_byte = data[pos]
             if (length_byte < 0xFB):
                 length = length_byte
@@ -626,82 +754,10 @@ class BaseClient(ABC):
                 length = _unpack_Q(data, pos + 1)[0]
                 pos += 9
 
-            col_type = column.type
-            if col_type in (FIELD_TYPE.TINY, FIELD_TYPE.SHORT, FIELD_TYPE.LONG, FIELD_TYPE.LONGLONG, FIELD_TYPE.INT24, FIELD_TYPE.YEAR):
-                row_values[i] = int(data_bytes[pos:pos + length])
-            elif col_type in (FIELD_TYPE.VARCHAR, FIELD_TYPE.BIT, FIELD_TYPE.ENUM, FIELD_TYPE.SET, \
-                              FIELD_TYPE.TINY_BLOB, FIELD_TYPE.MEDIUM_BLOB, FIELD_TYPE.LONG_BLOB, FIELD_TYPE.BLOB, FIELD_TYPE.VAR_STRING, \
-                              FIELD_TYPE.STRING, FIELD_TYPE.GEOMETRY):
-                # String types and others
-                if column.special_format:
-                    if column.ext_type_format == b'json':
-                        row_values[i] = data_bytes[pos:pos + length].decode('utf-8', errors='ignore')
-                    elif column.ext_type_name == b'inet6' or column.ext_type_name == b'inet4':
-                        row_values[i] = data_bytes[pos:pos + length].decode('ascii')
-                        if config.native_object:
-                            row_values[i] = ipaddress.ip_address(row_values[i])
-                    elif column.ext_type_name == b'uuid':
-                        row_values[i] = data_bytes[pos:pos + length].decode('ascii')
-                        if config.native_object:
-                            row_values[i] = uuid.UUID(row_values[i])
-                elif column.character_set == 63:  # Binary
-                    row_values[i] = data_bytes[pos:pos + length]
-                else:
-                    row_values[i] = data_bytes[pos:pos + length].decode('utf-8', errors='ignore')
-            elif col_type in (FIELD_TYPE.FLOAT, FIELD_TYPE.DOUBLE):
-                row_values[i] = float(data_bytes[pos:pos + length].decode('ascii'))
-            elif col_type in (FIELD_TYPE.DECIMAL, FIELD_TYPE.NEWDECIMAL):
-                row_values[i] = decimal.Decimal(data_bytes[pos:pos + length].decode('ascii'))
-            elif col_type in (FIELD_TYPE.DATE, FIELD_TYPE.NEWDATE):
-                # Fast date parsing: YYYY-MM-DD using struct
-                if length == 10:
-                    try:
-                        year_b, _, month_b, _, day_b = _unpack_DATE_TEXT(data_bytes, pos)
-                        row_values[i] = datetime.date(int(year_b), int(month_b), int(day_b))
-                    except (ValueError, struct.error):
-                        row_values[i] = None
-                else:
-                    row_values[i] = None
-            elif col_type == FIELD_TYPE.TIME:
-                time_str = data_bytes[pos:pos + length].decode('ascii')
-                negative = time_str[0] == '-'
-                if negative:
-                    time_str = time_str[1:]
-                parts = time_str.split(':')
-                if len(parts) == 3:
-                    hours = int(parts[0])
-                    minutes = int(parts[1])
-                    sec_parts = parts[2].split('.')
-                    seconds = int(sec_parts[0])
-                    microseconds = int(sec_parts[1].ljust(6, '0')) if len(sec_parts) > 1 else 0
-                    td = datetime.timedelta(hours=hours, minutes=minutes, seconds=seconds, microseconds=microseconds)
-                    row_values[i] = -td if negative else td
-                else:
-                    row_values[i] = None
-            elif col_type in (FIELD_TYPE.DATETIME, FIELD_TYPE.TIMESTAMP):
-                # Fast datetime parsing: YYYY-MM-DD HH:MM:SS[.ffffff] using struct
-                if length >= 19:
-                    try:
-                        year_b, _, month_b, _, day_b, _, hour_b, _, min_b, _, sec_b = _unpack_DATETIME_TEXT(data_bytes, pos)
-                        # Check for microseconds
-                        if length > 19 and data_bytes[pos+19] == 46:  # '.'
-                            microseconds = int(data_bytes[pos+20:pos+length].ljust(6, b'0'))
-                        else:
-                            microseconds = 0
-                        row_values[i] = datetime.datetime(
-                            int(year_b), int(month_b), int(day_b),
-                            int(hour_b), int(min_b), int(sec_b), microseconds
-                        )
-                    except (ValueError, struct.error):
-                        row_values[i] = None
-                else:
-                    row_values[i] = None
-            elif col_type == FIELD_TYPE.NULL:
-                row_values[i] = None
-            elif col_type == FIELD_TYPE.JSON:
-                row_values[i] = data_bytes[pos:pos + length].decode('utf-8', errors='ignore')
-
+            field_bytes = data_bytes[pos:pos+length]
             pos += length
+
+            row_values[i] = converters[i](field_bytes)
 
         return tuple(row_values)
 

--- a/mariadb/impl/client/sync_client.py
+++ b/mariadb/impl/client/sync_client.py
@@ -56,7 +56,7 @@ class SyncClient(BaseClient):
     # =========================================================================
     # Initialization
     # =========================================================================
-    
+
     def __init__(self, configuration: Configuration) -> None:
         """Initialize synchronous client with configuration"""
         super().__init__(configuration)
@@ -64,7 +64,7 @@ class SyncClient(BaseClient):
 
         # Sync-specific attributes
         self.socket: Optional[socket.socket] = None
-        
+
         # Read buffer management
         self._default_recv_buf: bytearray = bytearray(16384)
         self._default_recv_buf_mv = memoryview(self._default_recv_buf)  # Cache default memoryview
@@ -73,6 +73,7 @@ class SyncClient(BaseClient):
         self._recv_buf_capacity = 16384  # Cache buffer capacity
         self._recv_pos = 0
         self._recv_len = 0
+        self._last_payload= None
 
 
     # =========================================================================
@@ -89,7 +90,7 @@ class SyncClient(BaseClient):
         self._recv_buf = self._recv_buf + bytearray(grow_size)
         self._recv_buf_mv = memoryview(self._recv_buf)
         self._recv_buf_capacity += grow_size
-                
+
 
     def _recv_into_buffer(self, size=0):
         """
@@ -100,19 +101,18 @@ class SyncClient(BaseClient):
 
         Returns the number of bytes read.
         """
-        
 
         received = 0
 
         # Keep trying to read until we have enough data or there's nothing left
         try:
             if size == 0:
-                n = self.socket.recv_into(self._recv_buf_mv[self._recv_len + received:])
+                n = self.socket.recv_into(self._recv_buf_mv[self._recv_len:])
                 if n == 0:
                     raise ConnectionError("Connection reset by peer")
                 return n
             while received < size:
-                n = self.socket.recv_into(self._recv_buf_mv[self._recv_len + received:], size - received)
+                n = self.socket.recv_into(self._recv_buf_mv[self._recv_len + received:])
                 if n == 0:
                     raise ConnectionError("Connection reset by peer")
                 received += n
@@ -128,108 +128,118 @@ class SyncClient(BaseClient):
             # Generic socket error (broken pipe, network down, etc.)
             raise ConnectionError(f"Socket error: {e}") from e
 
-    def read_payload(self):
+    def read_payload(self, packet_count: int = 1):
         """
-        Reads and returns a full packet from database server
+        Reads one or more complete packets from database server.
 
-        Returns a tuple which contains packet size and first offset
-        of the buffer
-
+        Returns:
+            packet_count == 1: memoryview
+            packet_count > 1 or -1: list of (start, end) tuples
         """
-        # if everything was read - rewind buffer
+        # --- 1. Top-Level Buffer Maintenance ---
+        # Shift data ONLY at the start of the call to protect caller references.
         if self._recv_pos >= self._recv_len:
-           self._recv_pos = 0
-           self._recv_len = 0
-
-        if self._recv_pos > 0 and self._recv_buf_capacity - self._recv_len < 1024:
+            self._recv_pos = 0
+            self._recv_len = 0
+        elif self._recv_pos > 0 and (packet_count != 1 or self._recv_buf_capacity - self._recv_len < 1024):
             unread = self._recv_len - self._recv_pos
             if unread > 0:
                 self._recv_buf[:unread] = self._recv_buf[self._recv_pos:self._recv_len]
             self._recv_len = unread
             self._recv_pos = 0
 
-        first_pos = self._recv_pos
-        total_size = 0
-        packet_count = 0
+        is_multi = (packet_count != 1)
+        results = [] if is_multi else None
 
         while True:
-            bytes_in_buffer = self._recv_len - self._recv_pos
+            first_pos = self._recv_pos
+            total_size = 0
+            pkt_seen = 0
 
-            if bytes_in_buffer > 0:
-                # buffer must contain at least a packet header
+            # --- 2. Primary Packet Assembly ---
+            while True:
+                bytes_in_buffer = self._recv_len - self._recv_pos
+
                 if bytes_in_buffer < 4:
-                    missing = 4 - bytes_in_buffer
-                    self._ensure_space(missing)
-                    self._recv_len += self._recv_into_buffer(missing)
-                    continue
+                    if self._recv_len == self._recv_buf_capacity:
+                        self._ensure_space(4)
+                    
+                    got = self._recv_into_buffer(4 - bytes_in_buffer)
+                    if got == 0: # Connection lost
+                        return results if is_multi else None
+                    self._recv_len += got
+                    bytes_in_buffer = self._recv_len - self._recv_pos
 
-                # Fast packet header parsing using struct
                 header_int = _unpack_pkt_hdr(self._recv_buf, self._recv_pos)[0]
                 packet_length = header_int & 0xFFFFFF
                 self.sequence[0] = (header_int >> 24) & 0xFF
-
-                # check if we have complete packet data
                 packet_total = 4 + packet_length
+
                 if bytes_in_buffer < packet_total:
-                    # Need to read more data
                     missing = packet_total - bytes_in_buffer
-                    # For MAX_PKT_SIZE packets, also try to read next packet header
                     if packet_length == 0xFFFFFF:
                         missing += 4
-                    self._ensure_space(missing)
-                    self._recv_len += self._recv_into_buffer(missing)
-                    continue
+                    
+                    if self._recv_len + missing > self._recv_buf_capacity:
+                        self._ensure_space(missing)
+                        
+                    got = self._recv_into_buffer(missing)
+                    if got == 0:
+                        return results if is_multi else None
+                    self._recv_len += got
+                    bytes_in_buffer = self._recv_len - self._recv_pos
 
-                # We have complete packet (header + payload)
-                packet_count += 1
-                
-                # Fast path: single packet (most common case)
-                if packet_length < 0xFFFFFF and packet_count == 1:
-                    # Single packet fast path - no compaction needed
-                    result_start = self._recv_pos + 4
-                    result_end = self._recv_pos + packet_total
-                    self._recv_pos = result_end
-                    return self._recv_buf_mv[result_start:result_end]
-                
-                # Multi-packet handling (MAX_PKT_SIZE)
-                if packet_count > 1:
-                    # Compact by removing intermediate header
+                pkt_seen += 1
+
+                # Chained Fragment Compaction logic (> 16MB)
+                if pkt_seen > 1:
                     payload_src = self._recv_pos + 4
                     payload_dst = first_pos + 4 + total_size
                     if payload_src != payload_dst:
-                        # Calculate how much data is after this packet
-                        data_after_packet = self._recv_len - (self._recv_pos + packet_total)
-                        # Move this packet's payload
+                        data_after = self._recv_len - (self._recv_pos + packet_total)
                         self._recv_buf[payload_dst:payload_dst + packet_length] = \
                             self._recv_buf[payload_src:payload_src + packet_length]
-                        # Move any data after this packet
-                        if data_after_packet > 0:
-                            self._recv_buf[payload_dst + packet_length:payload_dst + packet_length + data_after_packet] = \
-                                self._recv_buf[self._recv_pos + packet_total:self._recv_len]
-                        # After compaction, adjust buffer length to account for removed header
+                        if data_after > 0:
+                            # Avoid overlap issues using a temporary slice
+                            tmp = self._recv_buf[self._recv_pos + packet_total:self._recv_len]
+                            self._recv_buf[payload_dst + packet_length:
+                                           payload_dst + packet_length + data_after] = tmp
                         self._recv_len -= 4
-                
+
                 total_size += packet_length
 
-                # Check if this is the last packet
-                if packet_length < 0xFFFFFF:
-                    # Last packet in multi-packet sequence - return complete result
-                    result_start = first_pos + 4
-                    result_end = first_pos + 4 + total_size
-                    self._recv_pos = result_end
-                    return self._recv_buf_mv[result_start:result_end]
-
-                # Multi-packet: advance to next packet header
-                # After compaction, the next header is immediately after current payload
-                if packet_count > 1:
-                    # After compaction, next header is at: first_pos + 4 + total_size
+                if packet_length < 0xFFFFFF: # Final fragment seen
+                    p_start = first_pos + 4
+                    p_end = p_start + total_size
+                    self._recv_pos = p_end
+                    break
+                
+                # Move to next fragment header
+                if pkt_seen > 1:
                     self._recv_pos = first_pos + 4 + total_size
                 else:
-                    # First packet, no compaction yet
                     self._recv_pos += packet_total
-            else:
-                # No data in buffer, read more
-                self._recv_len += self._recv_into_buffer(0)
+
+            # --- 3. Result Handling ---
+            if not is_multi:
+                return self._recv_buf_mv[p_start : p_end]
+
+            # Store the (start, end) tuple
+            results.append((p_start, p_end))
+
+            # Terminator Logic (0xFE = EOF, 0xFF = ERR)
+            first_byte = self._recv_buf[p_start]
+            if first_byte >= 0xFE:
+                if first_byte == 0xFF or (p_end - p_start) < 9:
+                    return results
+
+            # Reached requested count
+            if packet_count > 0 and len(results) >= packet_count:
+                return results
+
+            # Stop if buffer exhausted and not in slurp mode
+            if self._recv_pos >= self._recv_len and packet_count != -1:
+                return results
 
     def reset_buffer(self):
         self._recv_buf = self._default_recv_buf
@@ -599,9 +609,9 @@ class SyncClient(BaseClient):
 
     def _read_result(self, is_binary: bool, config: 'Configuration' = None, buffered: bool = True, prepare_stmt_packet: Optional[PrepareStmtPacket] = None, sql: str = None) -> List[Completion]:
         from ..result import SyncStreamingResult, SyncCompleteResult
-        
+
         results = []
-        
+
         while True:
             packet = self.read_payload()
             packet_type = packet[0]
@@ -616,9 +626,9 @@ class SyncClient(BaseClient):
                 results.append(self._handle_local_infile(packet, sql))
                 # After sending file, read the actual result
                 if (self.context.server_status & STATUS.MORE_RESULTS_EXIST) == 0:
-                    break                
+                    break
                 continue
-            
+
             """Parse result set with column definitions and row data"""
             # Parse column count from first packet
             parser = PayloadReader(packet)
@@ -626,22 +636,33 @@ class SyncClient(BaseClient):
 
             # Cache EOF deprecated flag once
             eof_deprecated = self.context.isEofDeprecated()
-            
+
             # Read column definitions
             columns: List[ColumnDefinitionPacket] = [None] * column_count
             if self.context.has_capability(constants.CAPABILITY.CACHE_METDATA) and parser.read_byte() == 0:
                 # skip metadata
                 columns = prepare_stmt_packet.columns
             else:
-                for i in range(column_count):
+                if column_count < 2:
                     col_packet = self.read_payload()
-                    columns[i] = ColumnDefinitionPacket.decode(col_packet, self.context)
-                if prepare_stmt_packet is not None:
-                    prepare_stmt_packet.columns = columns
+                    columns= [ColumnDefinitionPacket.decode(col_packet, self.context)]
+                else:
+                    idx = 0
+                    packets = []
+                    while idx < column_count:
+                        packets.extend(self.read_payload(column_count - idx))
+
+                        while idx < len(packets):
+                            start, end= packets[idx]
+                            columns[idx] = ColumnDefinitionPacket.decode(self._recv_buf_mv[start:end], self.context)
+                            idx += 1
+
+                    if prepare_stmt_packet is not None:
+                        prepare_stmt_packet.columns = columns
             # Read EOF packet after column definitions (if not deprecated)
             if not eof_deprecated:
                 self.read_payload()  # Skip EOF packet
-            
+
             # Select appropriate row parser based on protocol
             row_parser = self._parse_binary_row_data if is_binary else self._parse_text_row_data
 
@@ -654,48 +675,60 @@ class SyncClient(BaseClient):
                     config,
                     row_parser
                 )
-                
+
                 # Register streaming result with client for tracking
                 self._active_streaming_result = streaming_result
-                
+
                 # Create completion with streaming result
                 completion = OkPacket(0,0,0,0,b'')
                 completion.result_set = streaming_result
                 results.append(completion)
                 return results
-            
+
             # Read rows
             rows: List[tuple] = []
-            
+
             # Pre-compute EOF/OK length threshold
             eof_length_threshold = 16777215 if eof_deprecated else 8
-            
+
             while True:
-                row_packet = self.read_payload()
-                packet_first_byte = row_packet[0]
-                
-                # Check for EOF/OK packet (0xFE with length constraint)
-                if packet_first_byte == 0xFE and len(row_packet) < eof_length_threshold:
-                    if eof_deprecated:
-                        completion = _decode_ok_packet(row_packet, self.context)
-                    else:
-                        completion = _decode_eof_packet(row_packet, self.context)
+                packets = self.read_payload(-1)
 
-                    if config.converter:
-                        rows = self._apply_converters_to_rows(rows, columns, config)
+                # Loop through the batch of packets
+                finish_result = False
+                for p in packets:
+                    row_packet= self._recv_buf_mv[p[0]:p[1]]
+                    packet_first_byte = row_packet[0]
 
-                    completion.result_set = SyncCompleteResult(
-                        columns,
-                        column_count,
-                        config,
-                        rows
-                    )
-                    results.append(completion)
+                    # Check for EOF/OK packet terminator
+                    if packet_first_byte == 0xFE and len(row_packet) < eof_length_threshold:
+                        if eof_deprecated:
+                            completion = _decode_ok_packet(row_packet, self.context)
+                        else:
+                            completion = _decode_eof_packet(row_packet, self.context)
+
+                        if config.converter:
+                            rows = self._apply_converters_to_rows(rows, columns, config)
+
+                        completion.result_set = SyncCompleteResult(
+                            columns,
+                            column_count,
+                            config,
+                            rows
+                        )
+                        results.append(completion)
+                        finish_result = True
+                        break
+
+                    # Check for Error packet
+                    elif packet_first_byte == self.ERROR_PACKET:
+                        raise _decode_error_packet(row_packet, self.context).toError(self.exception_factory)
+
+                    # Regular data row
+                    rows.append(row_parser(row_packet, columns, config, column_count))
+
+                if finish_result:
                     break
-                elif packet_first_byte == self.ERROR_PACKET:
-                    raise _decode_error_packet(row_packet, self.context).toError(self.exception_factory)
-                
-                rows.append(row_parser(row_packet, columns, config, column_count))
 
             if (self.context.server_status & STATUS.MORE_RESULTS_EXIST) == 0:
                 break

--- a/mariadb/impl/client/sync_client.py
+++ b/mariadb/impl/client/sync_client.py
@@ -19,7 +19,7 @@ from mariadb.impl.message.server.ok_packet import OkPacket
 from mariadb.impl.message.server.error_packet import ErrorPacket
 from mariadb.impl.message.server.eof_packet import EofPacket
 from mariadb.impl.message.server.prepare_stmt_packet import PrepareStmtPacket, CachedPrepareStmtPacket
-from mariadb.impl.message.server.column_definition_packet import ColumnDefinitionPacket
+from mariadb.impl.message.server.column_definition_packet import ColumnDefinitionPacket, ColumnsDefinitionPacket
 from .base_client import BaseClient
 from ..message.payload_reader import PayloadReader
 from ..configuration import Configuration
@@ -665,6 +665,7 @@ class SyncClient(BaseClient):
 
             # Select appropriate row parser based on protocol
             row_parser = self._parse_binary_row_data if is_binary else self._parse_text_row_data
+            self._set_txt_converters(columns, config)
 
             # If unbuffered, create streaming result
             if not buffered:


### PR DESCRIPTION
- Handle common data types (4- and 8-byte integers and strings) in if/elif blocks first

- read_payload() optimizations:

  - Reduced the number of recv_into calls
  - Added a new packet_count parameter:
    1: If omitted (default), a memoryview is returned
    2: If > 1, the method returns up to packet_count packets
    3:  If == -1, the method returns packets until an EOF or error packet is detected

    Note: read_payload() may return fewer packets than requested if
    subsequent packets are not yet stored in the read buffer.

    In cases (2) and (3), read_payload() returns a list of tuples
    specifying the start and end positions of each packet within
    self._recv_buf_mv, rather than a memoryview.