### PR TITLE
[CONPY-347] fix memory leak when raising MariaDB exceptions

### DIFF
--- a/mariadb/mariadb_cursor.c
+++ b/mariadb/mariadb_cursor.c
@@ -745,7 +745,7 @@ static PyObject *MrdbCursor_metadata(MrdbCursor *self)
 
     for (i=0; i < 13; i++)
     {
-        if (PyDict_SetItem(dict, PyUnicode_FromString(keys[i]), tuple[i]))
+        if (PyDict_SetItemString(dict, keys[i], tuple[i]))
             goto error;
         Py_DECREF(tuple[i]);
         tuple[i]= NULL;

--- a/mariadb/mariadb_exception.c
+++ b/mariadb/mariadb_exception.c
@@ -138,11 +138,11 @@ void mariadb_exception_connection_gone(PyObject *exception_type,
     return;
   }
 
-  PyObject_SetAttr(Exception, PyUnicode_FromString("sqlstate"), SqlState);
-  PyObject_SetAttr(Exception, PyUnicode_FromString("errno"), ErrorNo);
-  PyObject_SetAttr(Exception, PyUnicode_FromString("errmsg"), ErrorMsg);
+  PyObject_SetAttrString(Exception, "sqlstate", SqlState);
+  PyObject_SetAttrString(Exception, "errno", ErrorNo);
+  PyObject_SetAttrString(Exception, "errmsg", ErrorMsg);
   /* For MySQL Connector/Python compatibility */
-  PyObject_SetAttr(Exception, PyUnicode_FromString("msg"), ErrorMsg);
+  PyObject_SetAttrString(Exception, "msg", ErrorMsg);
   PyErr_SetObject(exception_type, Exception);
   Py_XDECREF(ErrorMsg);
   Py_XDECREF(ErrorNo);
@@ -206,11 +206,11 @@ void mariadb_throw_exception(void *handle,
     return;
   }
 
-  PyObject_SetAttr(Exception, PyUnicode_FromString("sqlstate"), SqlState);
-  PyObject_SetAttr(Exception, PyUnicode_FromString("errno"), ErrorNo);
-  PyObject_SetAttr(Exception, PyUnicode_FromString("errmsg"), ErrorMsg);
+  PyObject_SetAttrString(Exception, "sqlstate", SqlState);
+  PyObject_SetAttrString(Exception, "errno", ErrorNo);
+  PyObject_SetAttrString(Exception, "errmsg", ErrorMsg);
   /* For MySQL Connector/Python compatibility */
-  PyObject_SetAttr(Exception, PyUnicode_FromString("msg"), ErrorMsg);
+  PyObject_SetAttrString(Exception, "msg", ErrorMsg);
   PyErr_SetObject(exception_type, Exception);
   Py_XDECREF(ErrorMsg);
   Py_XDECREF(ErrorNo);


### PR DESCRIPTION
see https://jira.mariadb.org/browse/CONPY-347

* PyObject_SetAttr borrows the key reference, so the temporary PyUnicode returned by PyUnicode_FromString is never released. One unicode object leaks per attribute, per raised exception -> four per call, at two call sites in mariadb_exception.c
* A second instance of the same thing is also fixed in MrdbCursor_metadata (PyDict_SetItem(..., PyUnicode_FromString(key), ...) -> PyDict_SetItemString). This one only triggers if user code reads the MariaDB-specific cursor.metadata property