### PR TITLE
Fix escaped backslash at end of string literal preventing string closure

### DIFF
--- a/mariadb/mariadb_parser.c
+++ b/mariadb/mariadb_parser.c
@@ -129,6 +129,7 @@ MrdbParser_parse(MrdbParser *p, uint8_t is_batch,
 {
     char *a, *end;
     char lastchar = 0;
+    uint8_t escaped = 0;
     uint8_t i;
     PyObject *tmp;
 
@@ -162,15 +163,17 @@ MrdbParser_parse(MrdbParser *p, uint8_t is_batch,
                     else if (*a == '`') p->in_literal = LIT_BACKTICK;
                     break;
                 case LIT_SINGLE_QUOTE:
-                    if (*a == '\'' && lastchar != '\\')
+                    if (*a == '\'' && !escaped)
                         p->in_literal = LIT_NONE;
+                    escaped = (*a == '\\' && !escaped);
                     lastchar = *a;
                     a++;
                     continue;
 
                 case LIT_DOUBLE_QUOTE:
-                    if (*a == '"' && lastchar != '\\')
+                    if (*a == '"' && !escaped)
                         p->in_literal = LIT_NONE;
+                    escaped = (*a == '\\' && !escaped);
                     lastchar = *a;
                     a++;
                     continue;

--- a/testing/test/integration/test_cursor.py
+++ b/testing/test/integration/test_cursor.py
@@ -1882,6 +1882,56 @@ class TestCursor(unittest.TestCase):
                                 [[value, _]] = cursor.fetchall()
                                 self.assertEqual(value, 1)
 
+    def test_escaped_backslash_in_string_literal(self):
+        # An escaped backslash ('\\') inside a string literal must not cause
+        # the following string literal containing a '?' to be parsed as a
+        # parameter placeholder.
+        cursor = self.connection.cursor()
+
+        cursor.execute(
+            "CREATE TEMPORARY TABLE t1"
+                "(`id` INT, `a` VARCHAR(64), `b` VARCHAR(64))"
+        )
+
+        # backslash followed by an escaped quote, then a '?' literal
+        cursor.execute(r"INSERT IGNORE INTO t1 VALUES (1, '\\\'', '?')")
+        self.assertEqual(cursor.paramcount, 0)
+
+        # same escaping rules apply to double-quoted string literals
+        cursor.execute(r'INSERT IGNORE INTO t1 VALUES (2, "\\\"", "?")')
+        self.assertEqual(cursor.paramcount, 0)
+
+        # an escaped backslash must not swallow a following format placeholder
+        # that lives inside its own string literal
+        cursor.execute(r"INSERT IGNORE INTO t1 VALUES (3, '\\', '?')")
+        self.assertEqual(cursor.paramcount, 0)
+
+        cursor.execute(r"INSERT IGNORE INTO t1 VALUES (4, '\\', '%s')")
+        self.assertEqual(cursor.paramcount, 0)
+
+        # same escaping rules apply to double-quoted string literals
+        cursor.execute(r'INSERT IGNORE INTO t1 VALUES (5, "\\", "?")')
+        self.assertEqual(cursor.paramcount, 0)
+
+        cursor.execute(r'INSERT IGNORE INTO t1 VALUES (6, "\\", "%s")')
+        self.assertEqual(cursor.paramcount, 0)
+
+        cursor.execute("SELECT `id`, `a`, `b` FROM t1 ORDER BY `id`")
+        rows = cursor.fetchall()
+        self.assertEqual(
+            rows,
+            [
+                (1, '\\\'', '?'),
+                (2, '\\\"', '?'),
+                (3, '\\', '?'),
+                (4, '\\', '%s'),
+                (5, '\\', '?'),
+                (6, '\\', '%s'),
+            ],
+        )
+
+        cursor.close()
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
If a string literal ended with an escaped backslash that was being interpreted as an escaped quote preventing the string from ending. If the next string contained a ? or %s that was then treated as a parameter and a traceback was raised as the number of parameters in the statement didn't match the number supplied.

```
import mariadb

conn = mariadb.connect(user='root', database='db')
cursor = conn.cursor()

cursor.execute(r"INSERT INTO result VALUES (1, '\\', '?')")
```

```
Traceback (most recent call last):
  File "sql.py", line 6, in <module>
    cursor.execute(r"INSERT INTO result VALUES (1, '\\', '?')")
  File ".venv/lib64/python3.12/site-packages/mariadb/cursors.py", line 318, in execute
    self._parse_execute(statement, (data))
  File ".venv/lib64/python3.12/site-packages/mariadb/cursors.py", line 258, in _parse_execute
    self._check_execute_params()
  File ".venv/lib64/python3.12/site-packages/mariadb/cursors.py", line 195, in _check_execute_params
    raise mariadb.ProgrammingError(
mariadb.ProgrammingError: statement (1) doesn't match the number of data elements (0).
```