### PR TITLE
[CONPY-368] Return None for invalid/zero DATE and DATETIME instead of raising SystemError

### DIFF
--- a/mariadb/mariadb_codecs.c
+++ b/mariadb/mariadb_codecs.c
@@ -311,6 +311,8 @@ static uint8_t check_date(uint16_t year, uint8_t month, uint8_t day)
       return 0;
   if (month < 1 || month > 12)
       return 0;
+  if (day < 1 || day > 31)
+      return 0;
   if ((year % 4 == 0 && year % 100 != 0) || (year % 400 == 0))
       is_leap= 1;
   if (month == 2)
@@ -762,7 +764,8 @@ field_fetch_callback(void *data, unsigned int column, unsigned char **row)
                 len= (uint8_t)mysql_net_field_length(row);
                 if (!len)
                 {
-                    self->values[column]= PyDateTime_FromDateAndTime(0,0,0,0,0,0,0);
+                    Py_INCREF(Py_None);
+                    self->values[column]= Py_None;
                     break;
                 }
                 year= uint2korr(*row);
@@ -776,8 +779,22 @@ field_fetch_callback(void *data, unsigned int column, unsigned char **row)
                 }
                 if (len == 11)
                     second_part= uint4korr(*row + 7);
-                self->values[column]= PyDateTime_FromDateAndTime(year, month,
-                    day, hour, minute, second, second_part);
+                if (check_date(year, month, day))
+                {
+                    self->values[column]= PyDateTime_FromDateAndTime(year, month,
+                        day, hour, minute, second, second_part);
+                    if (!self->values[column])
+                    {
+                        PyErr_Clear();
+                        Py_INCREF(Py_None);
+                        self->values[column]= Py_None;
+                    }
+                }
+                else
+                {
+                    Py_INCREF(Py_None);
+                    self->values[column]= Py_None;
+                }
                 *row+= len;
                 break;
             }
@@ -790,12 +807,28 @@ field_fetch_callback(void *data, unsigned int column, unsigned char **row)
 
                 if (!len)
                 {
+                    Py_INCREF(Py_None);
+                    self->values[column]= Py_None;
                     break;
                 }
                 year= uint2korr(*row);
                 month= uint1korr(*row + 2);
                 day= uint1korr(*row + 3);
-                self->values[column]= PyDate_FromDate(year, month, day);
+                if (check_date(year, month, day))
+                {
+                    self->values[column]= PyDate_FromDate(year, month, day);
+                    if (!self->values[column])
+                    {
+                        PyErr_Clear();
+                        Py_INCREF(Py_None);
+                        self->values[column]= Py_None;
+                    }
+                }
+                else
+                {
+                    Py_INCREF(Py_None);
+                    self->values[column]= Py_None;
+                }
                 *row+= len;
                 break;
             }

--- a/testing/test/integration/test_cursor.py
+++ b/testing/test/integration/test_cursor.py
@@ -238,6 +238,30 @@ class TestCursor(unittest.TestCase):
         self.assertEqual(row[3], c4)
         cursor.close()
 
+    def test_conpy368(self):
+        # Dates with a zero component (day=0 or 0000-00-00) that the server
+        # accepts under a lenient sql_mode are not representable in Python.
+        # Before the fix, fetch raised SystemError; now they must yield None.
+        if is_mysql():
+            self.skipTest("MySQL rejects these zero-date values")
+        cursor = self.connection.cursor()
+        cursor.execute("SET SESSION sql_mode=''")
+        cursor.execute("CREATE TEMPORARY TABLE test_zero_dates("
+                       "id INT PRIMARY KEY, d DATE, dt DATETIME, ts TIMESTAMP NULL)")
+        cursor.execute("INSERT INTO test_zero_dates VALUES "
+                       "(1, '2008-08-00', '2008-08-00 12:34:56', '0000-00-00 00:00:00')")
+
+        # Protocolo texto (execute sem parametros)
+        cursor.execute("SELECT d, dt, ts FROM test_zero_dates WHERE id=1")
+        row = cursor.fetchone()
+        self.assertEqual(row, (None, None, None))
+
+        # Protocolo binario (prepared statement, com parametro)
+        cursor.execute("SELECT d, dt, ts FROM test_zero_dates WHERE id=?", (1,))
+        row = cursor.fetchone()
+        self.assertEqual(row, (None, None, None))
+        cursor.close()
+
     def test_numbers(self):
         cursor = self.connection.cursor()
         cursor.execute("CREATE TEMPORARY TABLE test_numbers ("


### PR DESCRIPTION
Fixes [CONPY-368](https://jira.mariadb.org/browse/CONPY-368).

### Problem
When a resultset contains a DATE/DATETIME/TIMESTAMP with a zero component
(`'2008-08-00'`, `'0000-00-00 00:00:00'`, ...) — accepted by MariaDB under a
lenient `sql_mode` and common in legacy data — fetch raised:

```
SystemError: <method 'fetchrows' of 'mariadb.cursor' objects>
             returned a result with an exception set
```

The C code called `PyDate_FromDate()`/`PyDateTime_FromDateAndTime()` directly;
CPython set a `ValueError` but the C function returned non-NULL with the error
still set (C-API protocol violation), so the whole cursor was aborted and no
rows of the batch were returned.

### Fix
- `check_date()` now validates the day (1..31) too; previously only year and
  month were checked.
- Binary DATE and DATETIME/TIMESTAMP fetch paths guard with `check_date()`
  before conversion and clear any pending error, returning `None` for values
  Python cannot represent. The empty-length case yields `None` instead of a
  zeroed datetime.
- The text protocol path already routed through `check_date()` and benefits
  from the stricter day validation.

Matches the behavior of mysqlclient / PyMySQL for legacy zero-dates.

### Test
Added `test_conpy368` to `testing/test/integration/test_cursor.py`, covering
both the text and binary protocols for DATE, DATETIME and TIMESTAMP zero values.

### Licensing
This contribution is licensed under the 3-clause BSD license.
